### PR TITLE
Rely on ruby's load path when requiring source files

### DIFF
--- a/spec/features/eq_wo_order_spec.rb
+++ b/spec/features/eq_wo_order_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/eq_wo_order'
+require 'eq_wo_order'
 
 describe '#eq_wo_order' do
   describe 'basic types' do


### PR DESCRIPTION
Ruby has something called the "load path" that works in much the same
way as bash's $PATH. When you require a file, ruby will iterate over all
of the directories in the load path until it finds the one that contains
the file being required.

If you want to add a path to ruby's load path, you can

``` ruby
$: << "/some/path/to/a/dir"
```

The good news is that you don't have to do that when building a gem.
Rubygems and Bundler work together to add the correct paths (for the
correct gem version) to your load path so that when you require a file,
it will always be there for you :)

Code that uses `require_relative`, often times is doing something out of
the ordinary or ad-hoc. Since we're in a gem here, there's no need to
step outside of the normal ruby conventions.

Replace call to `require_relative` with a more succinct call to
`require`.
