### PR TITLE
Rely on Enumerable#any? & #all? and use recursion

### DIFF
--- a/lib/eq_wo_order.rb
+++ b/lib/eq_wo_order.rb
@@ -1,59 +1,34 @@
 RSpec::Matchers.define :eq_wo_order do |expected|
   match do |actual|
-    eq_wo_order_base(actual, expected)
+    eq_wo_order(actual, expected)
   end
 
-  def eq_wo_order_base(actual, expected)
+  def eq_wo_order(actual, expected)
     return false unless actual.class == expected.class
 
     case actual
-      when Array
-        primitive_items_match?(actual, expected) &&
-          array_items_match?(actual, expected) &&
-          hash_items_match?(actual, expected)
-      when Hash
-        all_items_in_source?(actual, expected) && all_items_in_source?(expected, actual)
-      else
-        actual == expected
+    when Array
+      arrays_match?(actual, expected)
+    when Hash
+      hashes_match?(actual, expected)
+    else
+      actual == expected
     end
   end
 
-  def primitive_items_match?(actual, expected)
-    actual_primitive_items = primitives(actual)
-    expected_primitive_items = primitives(expected)
-    sort_as_s(actual_primitive_items) == sort_as_s(expected_primitive_items)
-  end
-
-  def hash_items_match?(actual, expected)
-    actual_hash_items = actual.grep(Hash)
-    expected_hash_items = expected.grep(Hash)
-    all_items_in_source?(actual_hash_items, expected_hash_items) &&
-      all_items_in_source?(expected_hash_items, actual_hash_items)
-  end
-
-  def array_items_match?(actual, expected)
-    actual_array_items = actual.grep(Array)
-    expected_array_items = expected.grep(Array)
-    all_items_in_source?(actual_array_items, expected_array_items) &&
-      all_items_in_source?(expected_array_items, actual_array_items)
-  end
-
-  def primitives(list)
-    list.find_all { |x| x.class != Hash && x.class != Array }
-  end
-
-  # given one array of arrays/hashes
-  # and another array of arrays/hashes
-  # are all the items of the first found in the second?
-  def all_items_in_source?(search, source)
-    search.map do |search_item|
-      source.any? do |source_item|
-        eq_wo_order_base search_item, source_item
+  def arrays_match?(actual, expected)
+    return false unless actual.length == expected.length
+    expected.all? do |expected_item|
+      actual.any? do |candidate|
+        eq_wo_order(candidate, expected_item)
       end
-    end.all?
+    end
   end
 
-  def sort_as_s(arr)
-    arr.sort_by(&:to_s)
+  def hashes_match?(actual, expected)
+    return false unless arrays_match?(actual.keys, expected.keys)
+    expected.all? do |expected_key, expected_value|
+      eq_wo_order(actual[expected_key], expected_value)
+    end
   end
 end


### PR DESCRIPTION
Please reject this pull-request.

It's hard to come up with reasoning for why I did things this way, other
than it's just how I think. The two fundamental things that my mind
immediately noticed were:
1. Ruby's built-in `Enumerable#any?` and `#all?` could really help
2. We could benefit from a touch of recursion, since nested items need
    to get the same treatment as root-level items

Extract two methods:
1. `#arrays_match?`
    This method first asserts that the two arrays are of the same
    length then iterates over each item in the expected collection to make
    sure that at least one of the items in the actual collection contains a
    match. We rely on the `eq_wo_order` to do the final comparison between
    all values.
2. `#hashes_match?`
    Similaraly to the #1, this method asserts that the two items have
    equivalent keys then iterates over each key/value pair in the expected
    collection, searching for any item that has a matching value at the
    given key.

These methods allow us to simplify the top-level case statement.

This was really just a fun challenge for myself to see if I could get the tests to pass. I have no idea if it
actually works.
